### PR TITLE
Fix token ordering issue in Transactions table

### DIFF
--- a/src/components/transactions/TransactionsTablePool.js
+++ b/src/components/transactions/TransactionsTablePool.js
@@ -2,8 +2,14 @@ import TransactionsTable from './TransactionsTable';
 
 import { getAnalyticsDexscanPoolTransactions } from '../../api/kaddex-analytics';
 
+const sort_tokens = ([tokenA, tokenB]) => tokenA === "KDA" ? [tokenB, tokenA] :
+                                          tokenB === "KDA" ? [tokenA, tokenB] :
+                                          tokenA < tokenB  ? [tokenA, tokenB] :
+                                                             [tokenB, tokenA]
+
+
 const TransactionsTablePool = ({pool}) => {
-  const [tokenA, tokenB] = pool.split(":").sort((a,b) => (a==="KDA" || a>b)?1:-1)
+  const [tokenA, tokenB] = sort_tokens(pool.split(":"))
 
   return <TransactionsTable tokenA={tokenA} tokenB={tokenB} load_fct={(...args) => getAnalyticsDexscanPoolTransactions(pool, ...args)} />
 }


### PR DESCRIPTION
Fix the ordering bug of tokens in data table.
The bug was due to a buggy compare function and only appeared on Chrome.
But it was working "by chance" on Firefox